### PR TITLE
Fix macOS versions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/updateTwitterList.yml
+++ b/.github/workflows/updateTwitterList.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-12
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub Actions deprecated macOS 12 images. I updated the version to `macos-latest`

https://github.com/actions/runner-images/issues/10721